### PR TITLE
Consolidate Postgres database config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,34 +1,42 @@
 # Environment variables for WAVE Backend
 
-# Database Configuration
-DATABASE_URL=postgresql+asyncpg://wave_user:wave_password@localhost:5432/wave_dev
-DATABASE_URL_TEST=postgresql+asyncpg://wave_user:wave_password@localhost:5433/wave_test
-
-# PostgreSQL Configuration
-POSTGRES_DB=wave_dev
-POSTGRES_TEST_DB=wave_test
+# === DATABASE CONFIGURATION ===
+# Individual PostgreSQL connection parameters (RECOMMENDED)
+# These are used to construct database URLs automatically
+POSTGRES_HOST=localhost
 POSTGRES_USER=wave_user
 POSTGRES_PASSWORD=wave_password
-POSTGRES_PORT=5432
-POSTGRES_TEST_PORT=5433
 
-# FastAPI Configuration
+# Development database
+POSTGRES_PORT=5432
+POSTGRES_DB=wave_dev
+
+# Test database (for running tests)
+POSTGRES_TEST_PORT=5433
+POSTGRES_TEST_DB=wave_test
+
+# === DATABASE URL OVERRIDES (OPTIONAL) ===
+# If you prefer to specify complete URLs, these will override the individual parameters above
+# DATABASE_URL=postgresql+asyncpg://wave_user:wave_password@localhost:5432/wave_dev
+# DATABASE_URL_TEST=postgresql+asyncpg://wave_user:wave_password@localhost:5433/wave_test
+
+# === SQLALCHEMY CONFIGURATION ===
+SQLALCHEMY_ECHO=false  # Set to true to enable SQL statement logging
+
+# === FASTAPI CONFIGURATION ===
 FASTAPI_HOST=0.0.0.0
 FASTAPI_PORT=8000
 FASTAPI_RELOAD=true
 
-# Logging Configuration
+# === LOGGING CONFIGURATION ===
 LOG_LEVEL=INFO
 LOG_CFG=logging_config.ini
 
-# SQLAlchemy Configuration
-SQLALCHEMY_ECHO=false  # Set to true to enable SQL statement logging
-
-# Development Settings
+# === DEVELOPMENT SETTINGS ===
 DEBUG=true
 ENVIRONMENT=development
 
-# Authentication Configuration
+# === AUTHENTICATION CONFIGURATION ===
 WAVE_API_KEY=your_api_key_here
 # Required for development: The root validator key that cross checks against user API keys
 ROOT_VALIDATOR_KEY=root-validator-key-here

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
 

--- a/src/wave_backend/api/routes/experiment_data.py
+++ b/src/wave_backend/api/routes/experiment_data.py
@@ -352,7 +352,7 @@ async def update_experiment_data(
     summary="Delete experiment data row",
     description="Delete a specific experiment data row by its ID.",
 )
-@auth.role(Role.RESEARCHER)
+@auth.role(Role.ADMIN)
 async def delete_experiment_data(
     experiment_id: UUID,
     row_id: int,

--- a/src/wave_backend/api/routes/experiment_types.py
+++ b/src/wave_backend/api/routes/experiment_types.py
@@ -95,7 +95,7 @@ async def update_experiment_type(
 
 
 @router.delete("/{experiment_type_id}")
-@auth.role(Role.RESEARCHER)
+@auth.role(Role.ADMIN)
 async def delete_experiment_type(
     experiment_type_id: int, db: AsyncSession = Depends(get_db), auth: Tuple[str, Role] = None
 ):  # noqa: F841

--- a/src/wave_backend/api/routes/tags.py
+++ b/src/wave_backend/api/routes/tags.py
@@ -79,7 +79,7 @@ async def update_tag(
 
 
 @router.delete("/{tag_id}")
-@auth.role(Role.RESEARCHER)
+@auth.role(Role.ADMIN)
 async def delete_tag(
     tag_id: int, db: AsyncSession = Depends(get_db), auth: Tuple[str, Role] = None
 ):  # noqa: F841

--- a/src/wave_backend/models/database.py
+++ b/src/wave_backend/models/database.py
@@ -1,18 +1,11 @@
 """Database configuration and connection."""
 
-import os
-
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase
 
-DATABASE_URL = os.getenv(
-    "DATABASE_URL", "postgresql+asyncpg://wave_user:wave_password@localhost:5432/wave_dev"
-)
+from wave_backend.models.database_config import db_config
 
-# Control SQLAlchemy echo via environment variable (defaults to False for less verbosity)
-SQLALCHEMY_ECHO = os.getenv("SQLALCHEMY_ECHO", "false").lower() in ("true", "1", "yes")
-
-engine = create_async_engine(DATABASE_URL, echo=SQLALCHEMY_ECHO)
+engine = create_async_engine(db_config.get_database_url(), echo=db_config.echo)
 AsyncSessionLocal = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
 

--- a/src/wave_backend/models/database_config.py
+++ b/src/wave_backend/models/database_config.py
@@ -1,0 +1,87 @@
+"""Centralized database configuration module.
+
+This module provides a single source of truth for all database configuration,
+eliminating inconsistencies between different parts of the application.
+"""
+
+import os
+
+
+class DatabaseConfig:
+    """Centralized database configuration class."""
+
+    def __init__(self):
+        """Initialize database configuration from environment variables."""
+        # Base PostgreSQL configuration
+        self.host: str = os.getenv("POSTGRES_HOST", "localhost")
+        self.user: str = os.getenv("POSTGRES_USER", "wave_user")
+        self.password: str = os.getenv("POSTGRES_PASSWORD", "wave_password")
+
+        # Development database configuration
+        self.dev_port: str = os.getenv("POSTGRES_PORT", "5432")
+        self.dev_db: str = os.getenv("POSTGRES_DB", "wave_dev")
+
+        # Test database configuration
+        self.test_port: str = os.getenv("POSTGRES_TEST_PORT", "5433")
+        self.test_db: str = os.getenv("POSTGRES_TEST_DB", "wave_test")
+
+        # SQLAlchemy configuration
+        self.echo: bool = os.getenv("SQLALCHEMY_ECHO", "false").lower() in ("true", "1", "yes")
+
+    def get_database_url(self, test: bool = False) -> str:
+        """Get the complete database URL.
+
+        Args:
+            test: If True, return test database URL, otherwise development URL
+
+        Returns:
+            Complete PostgreSQL async URL
+        """
+        port = self.test_port if test else self.dev_port
+        db_name = self.test_db if test else self.dev_db
+
+        # Check for explicit DATABASE_URL override first
+        if test:
+            explicit_url = os.getenv("DATABASE_URL_TEST")
+            if explicit_url:
+                return explicit_url
+        else:
+            explicit_url = os.getenv("DATABASE_URL")
+            if explicit_url:
+                return explicit_url
+
+        # Build URL from components
+        return f"postgresql+asyncpg://{self.user}:{self.password}@{self.host}:{port}/{db_name}"
+
+    def get_sync_database_url(self, test: bool = False) -> str:
+        """Get synchronous database URL (for migrations, etc.).
+
+        Args:
+            test: If True, return test database URL, otherwise development URL
+
+        Returns:
+            Complete PostgreSQL sync URL
+        """
+        async_url = self.get_database_url(test=test)
+        return async_url.replace("postgresql+asyncpg://", "postgresql://")
+
+    def get_connection_params(self, test: bool = False) -> dict:
+        """Get database connection parameters as a dictionary.
+
+        Args:
+            test: If True, return test database params, otherwise development params
+
+        Returns:
+            Dictionary with connection parameters
+        """
+        return {
+            "host": self.host,
+            "port": int(self.test_port if test else self.dev_port),
+            "user": self.user,
+            "password": self.password,
+            "database": self.test_db if test else self.dev_db,
+        }
+
+
+# Global configuration instance
+db_config = DatabaseConfig()


### PR DESCRIPTION
## Summary

This PR consolidates database configuration and enhances security permissions for production deployment. The
changes focus on centralizing PostgreSQL initialization, updating CI dependencies, and strengthening access
controls for critical operations.

## Key Changes

### 🔧 Database Configuration Consolidation
- **NEW**: Added centralized `DatabaseConfig` class in `src/wave_backend/models/database_config.py`
- Provides single source of truth for all database configuration
- Supports both development and test database environments
- Handles explicit `DATABASE_URL` overrides for production deployments
- Eliminates configuration inconsistencies across the application

### 🔒 Enhanced Security Permissions
- **BREAKING**: Delete operations now require **admin-level permissions** (`Role.ADMIN`)
- Updated routes: experiment data, experiment types, and tags deletion endpoints
- Prevents accidental data loss by non-admin users

### 🏗️ CI/CD Infrastructure Updates
- Bumped uv version to Astral v6 in GitHub Actions CI
- Updated `.env.example` with comprehensive database configuration options
- Improved test database configuration in `tests/medium/conftest.py`

## Files Changed
- `.env.example` - Updated database configuration examples
- `.github/workflows/ci.yml` - Bumped uv to v6
- `src/wave_backend/api/routes/experiment_data.py` - Admin-only delete permissions
- `src/wave_backend/api/routes/experiment_types.py` - Admin-only delete permissions
- `src/wave_backend/api/routes/tags.py` - Admin-only delete permissions
- `src/wave_backend/models/database.py` - Refactored to use centralized config
- `src/wave_backend/models/database_config.py` - New centralized database configuration
- `tests/medium/conftest.py` - Updated test database configuration

## Breaking Changes
⚠️ **Delete endpoints now require admin permissions**: Users with researcher, test, or experimentee roles can no
longer perform delete operations on experiments, experiment types, or tags.
