### PR TITLE
Update docs for clarity on railway deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,6 @@ ENVIRONMENT=development
 WAVE_API_KEY=your_api_key_here
 # Required for development: The root validator key that cross checks against user API keys
 ROOT_VALIDATOR_KEY=root-validator-key-here
-WAVE_AUTH_CACHE_TTL=60  # Optional: defaults to 60 seconds
+# WAVE_AUTH_CACHE_TTL=60  # Optional: defaults to 60 seconds
 # WAVE_AUTH_BASE_URL=https://api.unkey.com/v2  # Optional: uses default
 # WAVE_AUTH_TIMEOUT=10.0  # Optional: defaults to 10.0 seconds

--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,6 @@ ENVIRONMENT=development
 WAVE_API_KEY=your_api_key_here
 # Required for development: The root validator key that cross checks against user API keys
 ROOT_VALIDATOR_KEY=root-validator-key-here
-# WAVE_AUTH_CACHE_TTL=300  # Optional: defaults to 300 seconds
+WAVE_AUTH_CACHE_TTL=60  # Optional: defaults to 60 seconds
 # WAVE_AUTH_BASE_URL=https://api.unkey.com/v2  # Optional: uses default
 # WAVE_AUTH_TIMEOUT=10.0  # Optional: defaults to 10.0 seconds

--- a/README.md
+++ b/README.md
@@ -196,17 +196,15 @@ docs/                      # Documentation
 
 ### Railway Deployment
 
-This project is configured for deployment on Railway using nixpacks auto-detection.
+This project is configured for deployment on Railway using the `railway.json` settings file.
 
 **Required Environment Variables:**
 - `ROOT_VALIDATOR_KEY` - Your Unkey root API key for authentication validation
+- `DATABASE_URL` - Provided automatically when you add a PostgreSQL service to your project, but you'll still need to manually add this environment variable to the backend instance (you'll know you did this correctly if you see a connection between your services on the Railway workspace)
 
 **Optional Environment Variables:**
 - `LOG_LEVEL` - Set to `INFO` or `WARNING` for production
 - `ENVIRONMENT` - Set to `production` for production deployments
-
-**Database:**
-Railway automatically provides `DATABASE_URL` when you add a PostgreSQL service to your project.
 
 **Deployment Workflow:**
 - Development happens on `main` branch with CI/CD validation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # WAVE Backend
 
+[![CI Tests](https://github.com/WAVE-Lab-Williams/wave-backend/actions/workflows/ci.yml/badge.svg)](https://github.com/WAVE-Lab-Williams/wave-backend/actions/workflows/ci.yml)
+[![Railway Live API](https://img.shields.io/badge/Railway-Live%20API-mediumpurple?logo=railway&logoColor=white)](https://wave-backend-production-8781.up.railway.app/docs)
+
 FastAPI backend for the WAVE lab with PostgreSQL database support.
 
 ## Repository Overview

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -389,50 +389,23 @@ logger.setLevel(logging.DEBUG)
 
 2. **Permission Design**:
    - Follow principle of least privilege
-   - Use hierarchical roles appropriately
    - Regularly audit user permissions in Unkey workspace
-
-3. **Network Security**:
-   - Use HTTPS for all API communications
-   - Implement proper timeout and retry logic
-   - Monitor for unusual authentication patterns
 
 ### Performance
 
-1. **Caching**:
-   - Use default cache TTL (300 seconds) for most use cases
-   - Clear cache when permissions change
-   - Monitor cache hit rates for optimization
+**Caching**:
+- Use default cache TTL (60 seconds) for most use cases
+- Clear cache when permissions change (not yet exposed via API)
+- Monitor cache hit rates for optimization (Not implemented)
 
-2. **API Usage**:
-   - Batch user operations when possible
-   - Implement circuit breakers for Unkey API calls
-   - Use async/await patterns for concurrent requests
-
-### Monitoring
-
-1. **Metrics to Track**:
-   - Authentication success/failure rates
-   - API response times from Unkey
-   - Cache hit/miss ratios
-   - Role distribution across requests
-
-2. **Alerting**:
-   - High authentication failure rates
-   - Unkey API unavailability
-   - Unusual permission escalation attempts
 
 ### Development
 
-1. **Environment Setup**:
-   - Use separate Unkey workspaces for dev/staging/production
-   - Implement proper key rotation procedures
-   - Document role assignments and permissions
+**Environment Setup**:
+- Use separate Unkey workspaces for dev/staging/production
+- Implement proper key rotation procedures
+- Document role assignments and permissions
 
-2. **Testing**:
-   - Write tests for all authentication scenarios
-   - Test network failure conditions
-   - Validate role hierarchy enforcement
 
 ---
 

--- a/src/wave_backend/api/middleware/versioning.py
+++ b/src/wave_backend/api/middleware/versioning.py
@@ -46,7 +46,7 @@ class VersioningMiddleware(BaseHTTPMiddleware):
             log_version_info(client_version, user_agent)
         elif user_agent:
             # Log user agent without version checking if no client version header
-            logger.debug(f"No client version header, User agent: {user_agent}")
+            logger.debug(f"No client version header specified for agent: {user_agent}")
 
         # Process the request
         response = await call_next(request)

--- a/src/wave_backend/auth/config.py
+++ b/src/wave_backend/auth/config.py
@@ -11,7 +11,7 @@ class AuthConfig(BaseModel):
 
     api_key: str = Field(..., min_length=1, description="Unkey root API key for validation")
     cache_ttl_seconds: int = Field(
-        default=300, description="Authentication cache TTL in seconds", gt=0, le=3600
+        default=60, description="Authentication cache TTL in seconds", gt=0, le=3600
     )
     base_url: str = Field(default="https://api.unkey.com/v2", description="Unkey API base URL")
     timeout_seconds: float = Field(


### PR DESCRIPTION
## Changes

- Add CI and deployment status badges to `README`
- Update Railway deployment documentation to clarify `DATABASE_URL` setup requirements
- Reduce default authentication cache TTL from 300 to 60 seconds for improved security
- Clarify client versioning debug logging message format
- Remove excessive monitoring and alerting sections from authentication documentation
- Update `.env.example` to reflect new 60-second cache TTL default